### PR TITLE
rename BlogFeed.vue to PostFeed.vue

### DIFF
--- a/src/components/views/PostFeed.vue
+++ b/src/components/views/PostFeed.vue
@@ -6,7 +6,7 @@
           <p class="text-center md:text-left text-3xl font-bold">{{tag.title}}</p>
           <p class="text-center md:text-left text-md">{{tag.description}}</p>
         </div>
-        <p v-else class="text-center text-3xl font-bold">Blog</p>
+        <p v-else class="text-center text-3xl font-bold">{{title}}</p>
       </div>
     </div>
     <divider />
@@ -58,7 +58,7 @@ import Divider from '@/components/helpers/Divider.vue';
 import PostPreview from '@/components/previews/Post.vue';
 
 export default {
-  name: 'blog-feed',
+  name: 'post-feed',
   components: {
     Divider,
     PostPreview,
@@ -67,6 +67,11 @@ export default {
     tag: {
       default: undefined,
       type: Object,
+      required: false,
+    },
+    title: {
+      default: 'Feed',
+      type: String,
       required: false,
     }
   },
@@ -113,7 +118,7 @@ export default {
 
       if (tempPosts) {
         this.isMorePosts = tempPosts.length > totalPosts;
-        if (this.isMorePosts) tempPosts.pop(); // Remove last blog post
+        if (this.isMorePosts) tempPosts.pop(); // Remove last post
 
         this.posts = tempPosts;
         this.page++;

--- a/src/pages/blog.vue
+++ b/src/pages/blog.vue
@@ -1,7 +1,7 @@
 <template>
   <main>
     <nav-bar current-page="Blog" />
-    <blog-feed />
+    <post-feed title="Blog"/>
     <back-to-top-button />
     <footer-bar current-page="Blog" />
   </main>
@@ -9,7 +9,7 @@
 
 <script>
 import NavBar from '@/components/structural/NavBar.vue';
-import BlogFeed from '@/components/views/BlogFeed.vue';
+import PostFeed from '@/components/views/PostFeed.vue';
 import FooterBar from '@/components/structural/FooterBar.vue';
 import BackToTopButton from '@/components/helpers/BackToTopButton.vue';
 
@@ -17,7 +17,7 @@ export default {
   name: 'blog',
   components: {
     NavBar,
-    BlogFeed,
+    PostFeed,
     BackToTopButton,
     FooterBar
   },

--- a/src/pages/tag/_.vue
+++ b/src/pages/tag/_.vue
@@ -1,7 +1,7 @@
 <template>
   <main>
     <nav-bar :current-page="currentPage" />
-    <blog-feed :tag="tag" />
+    <post-feed :tag="tag" />
     <back-to-top-button />
     <footer-bar :current-page="currentPage" />
   </main>
@@ -9,7 +9,7 @@
 
 <script>
 import NavBar from '@/components/structural/NavBar.vue';
-import BlogFeed from '@/components/views/BlogFeed.vue';
+import PostFeed from '@/components/views/PostFeed.vue';
 import FooterBar from '@/components/structural/FooterBar.vue';
 import BackToTopButton from '@/components/helpers/BackToTopButton.vue';
 
@@ -17,7 +17,7 @@ export default {
   name: 'tag',
   components: {
     NavBar,
-    BlogFeed,
+    PostFeed,
     BackToTopButton,
     FooterBar
   },

--- a/test/unit/components/PostFeed.spec.js
+++ b/test/unit/components/PostFeed.spec.js
@@ -1,15 +1,14 @@
 import { shallowMount } from '@vue/test-utils';
 import Chance from 'chance';
 import generatePost from '../../helpers/postGenerator';
-import BlogFeed from '@/components/views/BlogFeed.vue';
+import PostFeed from '@/components/views/PostFeed.vue';
 import PostPreview from '@/components/previews/Post.vue';
 import Divider from '@/components/helpers/Divider.vue';
 
 const chance = new Chance();
-
 const postLimit = 10;
 
-describe('BlogFeed component', () => {
+describe('PostFeed component', () => {
   let wrapper, fakePosts;
 
   const stubs = {
@@ -30,7 +29,7 @@ describe('BlogFeed component', () => {
       // mock nuxt content fetch to never resolve (stuck loading behavior)      
       nuxtContentMock.fetch.mockReturnValue(new Promise(() => ({})));
 
-      wrapper = shallowMount(BlogFeed, {
+      wrapper = shallowMount(PostFeed, {
         mocks: {
           $content: () => nuxtContentMock
         },
@@ -53,7 +52,7 @@ describe('BlogFeed component', () => {
       fakePosts = [];
       nuxtContentMock.fetch.mockResolvedValue(fakePosts);
 
-      wrapper = shallowMount(BlogFeed, {
+      wrapper = shallowMount(PostFeed, {
         mocks: {
           $content: () => nuxtContentMock
         },
@@ -66,18 +65,20 @@ describe('BlogFeed component', () => {
     });
   });
 
-  describe('given there are posts', () => {
+  describe('given there are posts and a title prop is given', () => {
+    const title = chance.string();
     beforeEach(() => {
       fakePosts = chance.n(generatePost, chance.integer({
         min: 1, max: postLimit
       }));
       nuxtContentMock.fetch.mockResolvedValue(fakePosts);
 
-      wrapper = shallowMount(BlogFeed, {
+      wrapper = shallowMount(PostFeed, {
         mocks: {
           $content: () => nuxtContentMock
         },
         stubs,
+        propsData: { title }
       });
     });
   
@@ -88,7 +89,7 @@ describe('BlogFeed component', () => {
     });
   
     it('contains the correct text', () => {
-      expect(wrapper.text()).toContain("Blog");
+      expect(wrapper.text()).toContain(title);
     });
   
     it('contains a Divider component', () => {
@@ -120,6 +121,16 @@ describe('BlogFeed component', () => {
     });
   });
 
+  describe('given no title prop is given', () => {  
+    beforeEach(() => {
+      wrapper = shallowMount(PostFeed);
+    });
+
+    it('contains the correct text', () => {
+      expect(wrapper.text()).toContain("Feed");
+    });
+  });
+
   describe('given there are more posts than can possibly be displayed on the page', () => {
     beforeEach(() => {
       fakePosts = chance.n(generatePost, chance.integer({
@@ -128,7 +139,7 @@ describe('BlogFeed component', () => {
       }));
       nuxtContentMock.fetch.mockResolvedValue(fakePosts);
 
-      wrapper = shallowMount(BlogFeed, {
+      wrapper = shallowMount(PostFeed, {
         mocks: {
           $content: () => nuxtContentMock,
         },
@@ -192,7 +203,7 @@ describe('BlogFeed component', () => {
 
       nuxtContentMock.fetch.mockResolvedValue(fakePosts);
 
-      wrapper = shallowMount(BlogFeed, {
+      wrapper = shallowMount(PostFeed, {
         mocks: {
           $content: () => nuxtContentMock
         },
@@ -228,7 +239,7 @@ describe('BlogFeed component', () => {
 
       nuxtContentMock.fetch.mockRejectedValue(fakeError);
 
-      wrapper = shallowMount(BlogFeed, {
+      wrapper = shallowMount(PostFeed, {
         mocks: {
           $content: () => nuxtContentMock,
           $nuxt: nuxtMock

--- a/test/unit/pages/blog.spec.js
+++ b/test/unit/pages/blog.spec.js
@@ -1,6 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import blog from '@/pages/blog.vue';
-import BlogFeed from '@/components/views/BlogFeed.vue';
+import PostFeed from '@/components/views/PostFeed.vue';
 import NavBar from '@/components/structural/NavBar.vue';
 import BackToTopButton from '@/components/helpers/BackToTopButton.vue';
 import FooterBar from '@/components/structural/FooterBar.vue';
@@ -22,8 +22,8 @@ describe('blog page', () => {
     expect(navBar.props('currentPage')).toEqual('Blog');
   });
 
-  it('contains the BlogFeed component', () => {
-    expect(wrapper.findComponent(BlogFeed).exists()).toBeTruthy();
+  it('contains the PostFeed component', () => {
+    expect(wrapper.findComponent(PostFeed).exists()).toBeTruthy();
   });
 
   it('contains the BackToTopButton component', () => {

--- a/test/unit/pages/contact.spec.js
+++ b/test/unit/pages/contact.spec.js
@@ -21,7 +21,7 @@ describe('contact page', () => {
     expect(navBar.props('currentPage')).toEqual('Contact');
   });
 
-  it('contains the BlogFeed component', () => {
+  it('contains the PostFeed component', () => {
     expect(wrapper.findComponent(ContactForm).exists()).toBeTruthy();
   });
 

--- a/test/unit/pages/tag/_.spec.js
+++ b/test/unit/pages/tag/_.spec.js
@@ -1,7 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import Chance from 'chance';
 import tag from '@/pages/tag/_.vue';
-import BlogFeed from '@/components/views/BlogFeed.vue';
+import PostFeed from '@/components/views/PostFeed.vue';
 import NavBar from '@/components/structural/NavBar.vue';
 import BackToTopButton from '@/components/helpers/BackToTopButton.vue';
 import FooterBar from '@/components/structural/FooterBar.vue';
@@ -104,8 +104,8 @@ describe('tag page', () => {
       expect(nuxtContentMock.fetch).toBeCalledTimes(1);
     });
 
-    it('renders a BlogFeed component with the correct prop', () => {
-      const feed = wrapper.findComponent(BlogFeed);
+    it('renders a PostFeed component with the correct prop', () => {
+      const feed = wrapper.findComponent(PostFeed);
       
       expect(feed.exists()).toBeTruthy();
       expect(feed.props('tag')).toEqual(fakeTag);


### PR DESCRIPTION
This turns BlogFeed.vue into PostFeed.vue.

One added feature is that PostFeed.vue now takes in a title prompt which is also tested